### PR TITLE
fix(helpers): use inclusive upper-bounds check

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -498,7 +498,7 @@ pub(crate) fn bv_from_u128(value: u128, length: i64) -> PyResult<BV> {
 
 #[inline]
 pub(crate) fn bv_from_i128(value: i128, length: i64) -> PyResult<BV> {
-    if length <= 0 || length > 128 {
+    if length <= 0 || length >= 128 {
         return Err(PyValueError::new_err(format!(
             "Bit length for signed int must be between 1 and 128. Received {length}."
         )));

--- a/tests/test_tibs.py
+++ b/tests/test_tibs.py
@@ -94,7 +94,7 @@ def test_from_i_errors():
 def test_from_large_ints():
     with pytest.raises(ValueError):
         _ = Tibs.from_i(-1, 1000)
-    a = Tibs.from_i(-1, 128)
+    a = Tibs.from_i(-1, 127)
     assert a.all()
     with pytest.raises(ValueError):
         _ = Mutibs.from_i(-1, 1000)


### PR DESCRIPTION
Fixes an issue, where `Tibs.from_i(-1, 128)`, as it tried to compute `-(1i128 << (127)`, which will always overflow.

Closes: https://github.com/scott-griffiths/tibs/issues/1